### PR TITLE
Add llms.txt, sitemap, and robots.txt

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,13 @@
 // @ts-check
 import { defineConfig, passthroughImageService } from "astro/config";
 
+import sitemap from "@astrojs/sitemap";
+
 // https://astro.build/config
 export default defineConfig({
     site: 'https://dawsoncall.com',
     image: {
         service: passthroughImageService(),
     },
+    integrations: [sitemap()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gaminglizard9.github.io",
       "version": "4.1.0",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "astro": "^5.15.3",
         "bulma": "^1.0.4",
         "sass": "^1.93.2",
@@ -65,6 +66,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1810,6 +1831,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1932,6 +1971,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4456,7 +4501,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4501,7 +4545,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
       "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -4604,6 +4647,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -4634,6 +4696,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4826,6 +4894,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -5807,7 +5881,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bulma-start": "npm run build-bulma -- --watch"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "astro": "^5.15.3",
     "bulma": "^1.0.4",
     "sass": "^1.93.2",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,20 @@
+# Dawson Call's Website
+
+> The personal website of Dawson Call. It introduces who he is, showcases websites he has designed and crossword puzzles he has constructed, links to his social media profiles, and hosts his personal blog.
+
+This site is built with the [Astro](https://astro.build) framework (compiled to static HTML and hosted on GitHub Pages) and the [Bulma](https://bulma.io) CSS library. The canonical domain is https://dawsoncall.com.
+
+## Pages
+
+- [Home](https://dawsoncall.com/): Introduction to Dawson, a gallery of websites he has built, the crossword puzzles he has constructed, and links to his social media profiles.
+- [Blog](https://dawsoncall.com/blog): Index of Dawson's blog posts, covering a range of his interests.
+
+## Blog posts
+
+- [Welcome to my blog!](https://dawsoncall.com/blog/first-post): Introduction to the blog and the features it currently supports (March 15, 2026).
+
+## Optional
+
+- [Sitemap](https://dawsoncall.com/sitemap-index.xml): Machine-readable XML index of every page on the site.
+- [Archived versions (gaminglizard9.github.io)](https://web.archive.org/web/20241201000000*/gaminglizard9.github.io): Older snapshots of the site on the Internet Archive.
+- [Archived versions (dawsoncall.com)](https://web.archive.org/web/20250000000000*/dawsoncall.com): More recent snapshots on the Internet Archive.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dawsoncall.com/sitemap-index.xml


### PR DESCRIPTION
## What changed

- **`public/llms.txt`** — a new [llmstxt.org](https://llmstxt.org/)-compliant file served at `/llms.txt`. It gives LLMs a curated map of the site: an H1 title, a blockquote summary, a short prose blurb about the tech stack, H2 link-list sections (`Pages`, `Blog posts`), and an `Optional` section linking the sitemap and Internet Archive snapshots.
- **Sitemap** — added the official [`@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/) integration in `astro.config.mjs`. The build now emits `sitemap-index.xml` (entry point) and `sitemap-0.xml`, auto-discovering all routes (`/`, `/blog/`, `/blog/first-post/`).
- **`public/robots.txt`** — allows all crawlers and points to `Sitemap: https://dawsoncall.com/sitemap-index.xml`.

## Why

So search engines and LLMs can discover and understand the site. The sitemap improves crawlability; llms.txt gives language models a concise, curated entry point.

## Notes for reviewers

- The Astro sitemap plugin names its output `sitemap-index.xml` + `sitemap-0.xml` rather than a single `sitemap.xml`; `robots.txt` references the index, which is the correct crawler entry point.
- The sitemap regenerates automatically on each build, so new pages/posts are included without manual edits. `llms.txt` is hand-curated and should be updated when site content changes.
- Verified with `npm run build`: all of `llms.txt`, `robots.txt`, `sitemap-index.xml`, and `sitemap-0.xml` land in `dist/`, and the sitemap lists all three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)